### PR TITLE
Add support for reading / writing string attributes

### DIFF
--- a/gamedata/tf2.attributes.txt
+++ b/gamedata/tf2.attributes.txt
@@ -129,6 +129,15 @@
 				"linux"				"@_ZN9CTFPlayer21RemoveCustomAttributeEPKc"
 				"mac"				"@_ZN9CTFPlayer21RemoveCustomAttributeEPKc"
 			}
+			"CopyStringAttributeValueToCharPointerOutput" //(CAttribute_String*, char**), returns void
+			{
+				// called from CAttributeIterator_GetTypedAttributeValue<CAttribute_String, char const*>::OnIterateAttributeValue
+				// which on Windows has a unique bytesig `55 8B EC 56 8B F1 8B 46 04 3B 45 08 75 ? FF 76 08`
+				"library"			"server"
+				"windows"			"\x55\x8B\xEC\x8B\x45\x08\x8B\x48\x10"
+				"linux"				"@_Z43CopyStringAttributeValueToCharPointerOutputPK17CAttribute_StringPPKc"
+				"mac"				"@_Z43CopyStringAttributeValueToCharPointerOutputPK17CAttribute_StringPPKc"
+			}
 		}
 	}
 }

--- a/gamedata/tf2.attributes.txt
+++ b/gamedata/tf2.attributes.txt
@@ -11,6 +11,27 @@
 				"linux"		"14"
 				"mac"		"14"
 			}
+			"ISchemaAttributeTypeBase::BConvertStringToEconAttributeValue"
+			{
+				"windows"	"4"
+				"linux"		"5"
+			}
+			"ISchemaAttributeTypeBase::InitializeNewEconAttributeValue"
+			{
+				"windows"	"7"
+				"linux"		"8"
+			}
+			"ISchemaAttributeTypeBase::UnloadEconAttributeValue"
+			{
+				"windows"	"8"
+				"linux"		"9"
+			}
+			"ISchemaAttributeTypeBase::BSupportsGame..."
+			{
+				// "ISchemaAttributeTypeBase::BSupportsGameplayModificationAndNetworking()"
+				"windows"	"10"
+				"linux"		"11"
+			}
 		}
 		"Signatures"
 		{

--- a/gamedata/tf2.attributes.txt
+++ b/gamedata/tf2.attributes.txt
@@ -11,6 +11,11 @@
 				"linux"		"14"
 				"mac"		"14"
 			}
+			"CAttributeManager::ApplyAttributeStringWrapper"
+			{
+				// linux uses a signature
+				"windows"	"15"
+			}
 			"ISchemaAttributeTypeBase::BConvertStringToEconAttributeValue"
 			{
 				"windows"	"4"
@@ -113,6 +118,14 @@
 				"library"			"server"
 				"linux"				"@_ZN17CAttributeManager15AttribHookValueIiEET_S1_PKcPK11CBaseEntityP10CUtlVectorIPS4_10CUtlMemoryIS8_iEEb"
 				"windows"			"\x55\x8B\xEC\x83\xEC\x10\x8B\x0D\x2A\x2A\x2A\x2A\x53\x56\x57\x33\xFF\x33\xDB\x89\x7D\xF0\x89\x5D\xF4\x8B\x41\x08\x85\xC0\x74\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x68\x2A\x2A\x2A\x2A\x6A\x6B"
+			}
+			"CAttributeManager::ApplyAttributeStringWrapper"
+			{
+				// uses a hidden pointer, which ends up looking something like this monstrosity:
+				// (string_t* returnValue, CAttributeManager* this, string_t input, CBaseEntity* initiator, string_t classname, CUtlVector<CBaseEntity*>* entityList), returns string_t
+				// windows uses a (mostly) standard calling convention so we use the vtable call for that
+				"library"			"server"
+				"linux"				"@_ZN17CAttributeManager27ApplyAttributeStringWrapperE8string_tP11CBaseEntityS0_P10CUtlVectorIS2_10CUtlMemoryIS2_iEE"
 			}
 			"CTFPlayer::AddCustomAttribute" //(const char*, float, float), returns void
 			{

--- a/scripting/include/tf2attributes.inc
+++ b/scripting/include/tf2attributes.inc
@@ -31,6 +31,10 @@ native bool TF2Attrib_SetByDefIndex(int iEntity, int iDefIndex, float flValue);
  * Parses the attribute name and value strings and applies it on the entity.  This parses
  * numeric and string attributes.
  * 
+ * If you use this on a non-numeric attribute, make sure that only the server reads off of that
+ * attribute.  Non-primitive values aren't replicated correctly between the client and the
+ * server; the client will read garbage and may crash!
+ * 
  * @param iEntity		Entity index to set the attribute on. Must have m_AttributeList.
  * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
  * @param strValue		Value to set the attribute to.

--- a/scripting/include/tf2attributes.inc
+++ b/scripting/include/tf2attributes.inc
@@ -67,22 +67,6 @@ native Address TF2Attrib_GetByName(int iEntity, const char[] strAttrib);
 native Address TF2Attrib_GetByDefIndex(int iEntity, int iDefIndex);
 
 /**
- * Returns the string value for a given attribute on an entity, if it exists.
- * This looks through the runtime, item server, and static attribute lists in that order, returning the first available value.
- * The result is *not* cached.
- *
- * @param iEntity		Entity index to get attribute from. Must have m_AttributeList.
- * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
- * 
- * @return				Number of bytes copied.
- * @error				Invalid entity index, invalid attribute name, or attribute is not a string value.
- * 
- * @deprecated			Use TF2Attrib_HookValueString() instead.  This function doesn't use the attribute cache, and checking attributes that don't exist incurs a massive performance penalty.
- */
-#pragma deprecated Use TF2Attrib_HookValueString() instead
-native int TF2Attrib_GetStringValue(int iEntity, const char[] strAttrib, char[] buffer, int maxlen);
-
-/**
  * Removes an attribute from an entity.
  *
  * @param iEntity		Entity index to remove attribute from. Must have m_AttributeList.

--- a/scripting/include/tf2attributes.inc
+++ b/scripting/include/tf2attributes.inc
@@ -28,6 +28,19 @@ native bool TF2Attrib_SetByName(int iEntity, const char[] strAttrib, float flVal
 native bool TF2Attrib_SetByDefIndex(int iEntity, int iDefIndex, float flValue);
 
 /**
+ * Parses the attribute name and value strings and applies it on the entity.  This parses
+ * numeric and string attributes.
+ * 
+ * @param iEntity		Entity index to set the attribute on. Must have m_AttributeList.
+ * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
+ * @param strValue		Value to set the attribute to.
+ * 
+ * @return				True if the attribute was added successfully, false if the attribute name was invalid.
+ * @error				Invalid entity index or entity does not have m_AttributeList.
+ */
+native bool TF2Attrib_SetFromStringValue(int iEntity, const char[] strAttrib, const char[] strValue);
+
+/**
  * Returns the address of an attribute on an entity.
  *
  * @param iEntity		Entity index to get attribute from. Must have m_AttributeList.
@@ -48,6 +61,17 @@ native Address TF2Attrib_GetByName(int iEntity, const char[] strAttrib);
  * @error				Invalid entity index or attribute index passed.
  */
 native Address TF2Attrib_GetByDefIndex(int iEntity, int iDefIndex);
+
+/**
+ * Returns the string value for a given attribute on an entity, if it exists.
+ *
+ * @param iEntity		Entity index to get attribute from. Must have m_AttributeList.
+ * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
+ * 
+ * @return				Number of bytes copied.
+ * @error				Invalid entity index, invalid attribute name, or attribute is not a string value.
+ */
+native int TF2Attrib_GetStringValue(int iEntity, const char[] strAttrib, char[] buffer, int maxlen);
 
 /**
  * Removes an attribute from an entity.

--- a/scripting/include/tf2attributes.inc
+++ b/scripting/include/tf2attributes.inc
@@ -69,13 +69,17 @@ native Address TF2Attrib_GetByDefIndex(int iEntity, int iDefIndex);
 /**
  * Returns the string value for a given attribute on an entity, if it exists.
  * This looks through the runtime, item server, and static attribute lists in that order, returning the first available value.
+ * The result is *not* cached.
  *
  * @param iEntity		Entity index to get attribute from. Must have m_AttributeList.
  * @param strAttrib		Name of the attribute, as from the "name" key in items_game.
  * 
  * @return				Number of bytes copied.
  * @error				Invalid entity index, invalid attribute name, or attribute is not a string value.
+ * 
+ * @deprecated			Use TF2Attrib_HookValueString() instead.  This function doesn't use the attribute cache, and checking attributes that don't exist incurs a massive performance penalty.
  */
+#pragma deprecated Use TF2Attrib_HookValueString() instead
 native int TF2Attrib_GetStringValue(int iEntity, const char[] strAttrib, char[] buffer, int maxlen);
 
 /**
@@ -164,10 +168,10 @@ native void TF2Attrib_SetValue(Address pAttrib, float flValue);
 native float TF2Attrib_GetValue(Address pAttrib);
 
 /**
- * Returns the string data from its raw value representation.
+ * Returns the string data from its raw value representation (a CAttribute_String instance).
  * 
  * WARNING: This dereferences the input value!  Feeding it values that aren't CAttribute_String pointers will result in unexpected behavior, potentially crashing the server.
- * In most cases, it's recommended to use TF2Attrib_GetStringValue instead.
+ * In the case where you only want the currently active value, use TF2Attrib_HookValueString instead.
  * 
  * @param pRawValue		Raw attribute value.  You can get this value with either TF2Attrib_GetValue, TF2Attrib_GetSOCAttribs, or TF2Attrib_GetStaticAttribs.
  * @param buffer		Buffer to store the resulting string to.
@@ -297,6 +301,19 @@ native float TF2Attrib_HookValueFloat(float flInitial, const char[] attrClass, i
  * @return					Transformed initial value.
  */
 native int TF2Attrib_HookValueInt(int nInitial, const char[] attrClass, int iEntity);
+
+/**
+ * Applies a transformation to the given initial value, following the rules according to the given attribute class.
+ * 
+ * @param initial			Initial string value.  (This appears to only be returned if the entity doesn't have the attribute.)
+ * @param attrClass			The attribute class, as from the "attribute_class" key in items_game.
+ * @param iEntity			The entity that should be checked.  Checking players also checks their equipped items.
+ * @param buffer			Transformed initial value.
+ * @param maxlen			Buffer size.
+ * 
+ * @return					Number of bytes written.
+ */
+native int TF2Attrib_HookValueString(const char[] initial, const char[] attrClass, int iEntity, char[] buffer, int maxlen);
 
 /**
  * Gets whether the plugin loaded without ANY errors.

--- a/scripting/include/tf2attributes.inc
+++ b/scripting/include/tf2attributes.inc
@@ -64,6 +64,7 @@ native Address TF2Attrib_GetByDefIndex(int iEntity, int iDefIndex);
 
 /**
  * Returns the string value for a given attribute on an entity, if it exists.
+ * This looks through the runtime, item server, and static attribute lists in that order, returning the first available value.
  *
  * @param iEntity		Entity index to get attribute from. Must have m_AttributeList.
  * @param strAttrib		Name of the attribute, as from the "name" key in items_game.

--- a/scripting/include/tf2attributes.inc
+++ b/scripting/include/tf2attributes.inc
@@ -160,6 +160,20 @@ native void TF2Attrib_SetValue(Address pAttrib, float flValue);
 native float TF2Attrib_GetValue(Address pAttrib);
 
 /**
+ * Returns the string data from its raw value representation.
+ * 
+ * WARNING: This dereferences the input value!  Feeding it values that aren't CAttribute_String pointers will result in unexpected behavior, potentially crashing the server.
+ * In most cases, it's recommended to use TF2Attrib_GetStringValue instead.
+ * 
+ * @param pRawValue		Raw attribute value.  You can get this value with either TF2Attrib_GetValue, TF2Attrib_GetSOCAttribs, or TF2Attrib_GetStaticAttribs.
+ * @param buffer		Buffer to store the resulting string to.
+ * @param maxlen		Maximum length of the buffer.
+ * 
+ * @return Number of bytes written.
+ */
+native int TF2Attrib_UnsafeGetStringValue(any pRawValue, char[] buffer, int maxlen);
+
+/**
  * Sets the value of m_nRefundableCurrency on an attribute.
  *
  * @param pAttrib		Address of the attribute.

--- a/scripting/tf2attributes.sp
+++ b/scripting/tf2attributes.sp
@@ -82,7 +82,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("TF2Attrib_GetDefIndex", Native_GetID);
 	CreateNative("TF2Attrib_SetValue", Native_SetVal);
 	CreateNative("TF2Attrib_GetValue", Native_GetVal);
-	CreateNative("TF2Attrib_GetStringValue", Native_GetStringVal);
+	CreateNative("TF2Attrib_UnsafeGetStringValue", Native_GetStringVal);
 	CreateNative("TF2Attrib_SetRefundableCurrency", Native_SetCurrency);
 	CreateNative("TF2Attrib_GetRefundableCurrency", Native_GetCurrency);
 	CreateNative("TF2Attrib_ClearCache", Native_ClearCache);

--- a/scripting/tf2attributes.sp
+++ b/scripting/tf2attributes.sp
@@ -85,7 +85,6 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("TF2Attrib_SetFromStringValue", Native_SetAttribStringByName);
 	CreateNative("TF2Attrib_GetByName", Native_GetAttrib);
 	CreateNative("TF2Attrib_GetByDefIndex", Native_GetAttribByID);
-	CreateNative("TF2Attrib_GetStringValue", Native_GetAttribString);
 	CreateNative("TF2Attrib_RemoveByName", Native_Remove);
 	CreateNative("TF2Attrib_RemoveByDefIndex", Native_RemoveByID);
 	CreateNative("TF2Attrib_RemoveAll", Native_RemoveAll);
@@ -621,79 +620,6 @@ public int Native_GetAttrib(Handle plugin, int numParams) {
 	return SDKCall(hSDKGetAttributeByID, pEntAttributeList, iDefIndex);
 }
 
-/* native int TF2Attrib_GetStringValue(int iEntity, const char[] strAttrib, char[] buffer, int maxlen); */
-public int Native_GetAttribString(Handle plugin, int numParams) {
-	int entity = GetNativeCell(1);
-	if (!IsValidEntity(entity)) {
-		return ThrowNativeError(SP_ERROR_NATIVE, "Entity %d (%d) is invalid", EntIndexToEntRef(entity), entity);
-	}
-	
-	char strAttrib[MAX_ATTRIBUTE_NAME_LENGTH];
-	GetNativeString(2, strAttrib, sizeof(strAttrib));
-	
-	Address pEntAttributeList = GetEntityAttributeList(entity);
-	if (!pEntAttributeList) {
-		return ThrowNativeError(SP_ERROR_NATIVE, "Entity %d (%d) does not have property m_AttributeList", EntIndexToEntRef(entity), entity);
-	}
-	
-	int attrdef;
-	if (!GetAttributeDefIndexByName(strAttrib, attrdef)) {
-		return ThrowNativeError(SP_ERROR_NATIVE, "Attribute name '%s' is invalid", strAttrib);
-	}
-	
-	// typecheck the input attribute by verifying that the attribute deftype matches
-	if (!IsAttributeString(attrdef)) {
-		return ThrowNativeError(SP_ERROR_NATIVE, "Attribute '%s' is not a string", strAttrib);
-	}
-	
-	/**
-	 * this is a mess.
-	 */
-	Address pRawValue = Address_Null;
-	
-	// try reading from runtime list
-	Address pEconItemAttribute = SDKCall(hSDKGetAttributeByID, pEntAttributeList, attrdef);
-	if (pEconItemAttribute) {
-		pRawValue = DereferencePointer(pEconItemAttribute, 0x08);
-	}
-	
-	// iterate over item server attributes if it's not in runtime
-	if (!pRawValue) {
-		int attrdefSOC;
-		any attrvalSOC;
-		for (int i, n = GetSOCAttribCount(entity); i < n && !pRawValue; i++) {
-			GetSOCAttribEntry(entity, i, attrdefSOC, attrvalSOC);
-			if (attrdefSOC == attrdef) {
-				pRawValue = attrvalSOC;
-			}
-		}
-	}
-	
-	// iterate over static attributes if it's not in runtime nor item server
-	if (!pRawValue && HasEntProp(entity, Prop_Send, "m_iItemDefinitionIndex")) {
-		int itemdef = GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex");
-		int attrdefSOC;
-		any attrvalSOC;
-		for (int i, n = GetStaticAttribCount(itemdef); i < n && !pRawValue; i++) {
-			GetStaticAttribEntry(itemdef, i, attrdefSOC, attrvalSOC);
-			if (attrdefSOC == attrdef) {
-				pRawValue = attrvalSOC;
-			}
-		}
-	}
-	
-	if (!pRawValue) {
-		return 0;
-	}
-	
-	int maxlen = GetNativeCell(4), length;
-	char[] buffer = new char[maxlen];
-	
-	ReadStringAttributeValue(pRawValue, buffer, maxlen);
-	SetNativeString(3, buffer, maxlen, .bytes = length);
-	return length;
-}
-
 /* native Address TF2Attrib_GetByDefIndex(int iEntity, int iDefIndex); */
 public int Native_GetAttribByID(Handle plugin, int numParams) {
 	int entity = GetNativeCell(1);
@@ -1064,100 +990,6 @@ static Address GetAttributeDefinitionByID(int id) {
 		return Address_Null;
 	}
 	return SDKCall(hSDKGetAttributeDef, pSchema, id);
-}
-
-/**
- * Returns the address of the CUtlVector<static_attrib_t>* containing attributes from the item
- * server.
- */
-static Address GetSOCAttribList(int iEntity) {
-	Address pEconItemView = GetEntityEconItemView(iEntity);
-	if (!pEconItemView) {
-		return Address_Null;
-	}
-	
-	// pEconItem may be null if the item doesn't have SOC data (i.e., not from the item server)
-	Address pEconItem = SDKCall(hSDKGetSOCData, pEconItemView);
-	if (!pEconItem) {
-		return Address_Null;
-	}
-	
-	// 0x34 = CEconItem.m_pAttributes (type CUtlVector<static_attrib_t>*, possibly null)
-	Address pCustomData = DereferencePointer(pEconItem, .offset = 0x34);
-	return pCustomData;
-}
-
-static int GetSOCAttribCount(int iEntity) {
-	Address pCustomData = GetSOCAttribList(iEntity);
-	if (!pCustomData) {
-		return 0;
-	}
-	
-	AssertValidAddress(pCustomData);
-	
-	// 0x0C = (...) m_pAttributes->m_Size (m_pAttributes + 0x0C)
-	// 0x00 = (...) m_pAttributes->m_Memory.m_pMemory (m_pAttributes + 0x00)
-	return LoadFromAddressOffset(pCustomData, 0x0C, NumberType_Int32);
-}
-
-static bool GetSOCAttribEntry(int iEntity, int index, int &attrdef, any &rawValue) {
-	Address pCustomData = GetSOCAttribList(iEntity);
-	if (!pCustomData) {
-		return false;
-	}
-	
-	AssertValidAddress(pCustomData);
-	
-	// 0x0C = (...) m_pAttributes->m_Size (m_pAttributes + 0x0C)
-	// 0x00 = (...) m_pAttributes->m_Memory.m_pMemory (m_pAttributes + 0x00)
-	if (index < 0 || index >= GetSOCAttribCount(iEntity)) {
-		return false;
-	}
-	
-	Address pCustomDataArray = DereferencePointer(pCustomData);
-	
-	// Read static_attrib_t (size 0x08) entries from contiguous block of memory
-	Address pSOCAttribEntry = pCustomDataArray + view_as<Address>(index * 0x08);
-	
-	attrdef = LoadFromAddress(pSOCAttribEntry, NumberType_Int16);
-	rawValue = LoadFromAddressOffset(pSOCAttribEntry, 0x04, NumberType_Int32);
-	return true;
-}
-
-static Address GetStaticAttribList(int iItemDefIndex) {
-	Address pSchema = GetItemSchema();
-	if (!pSchema) {
-		return Address_Null;
-	}
-	
-	// this always returns an itemdef, even if it's just falling back to default
-	Address pItemDef = SDKCall(hSDKGetItemDefinition, pSchema, iItemDefIndex);
-	
-	return pItemDef + view_as<Address>(0x1C);
-}
-
-static int GetStaticAttribCount(int iItemDefIndex) {
-	Address pAttribList = GetStaticAttribList(iItemDefIndex);
-	
-	// 0x1C = CEconItemDefinition.m_Attributes (type CUtlVector<static_attrib_t>)
-	// 0x1C = (...) m_Attributes.m_Memory.m_pMemory (m_Attributes + 0x00)
-	// 0x28 = (...) m_Attributes.m_Size (m_Attributes + 0x0C)
-	return LoadFromAddressOffset(pAttribList, 0xC, NumberType_Int32);
-}
-
-static bool GetStaticAttribEntry(int iItemDefIndex, int index, int &attrdef, any &rawValue) {
-	if (index < 0 || index >= GetStaticAttribCount(iItemDefIndex)) {
-		return false;
-	}
-	
-	Address pAttribList = GetStaticAttribList(iItemDefIndex);
-	Address pAttribData = DereferencePointer(pAttribList);
-	
-	// Read static_attrib_t (size 0x08) entries from contiguous block of memory
-	Address pStaticAttribEntry = pAttribData + view_as<Address>(index * 0x08);
-	attrdef = LoadFromAddress(pStaticAttribEntry, NumberType_Int16);
-	rawValue = LoadFromAddressOffset(pStaticAttribEntry, 0x04, NumberType_Int32);
-	return true;
 }
 
 /** 

--- a/scripting/tf2attributes.sp
+++ b/scripting/tf2attributes.sp
@@ -624,7 +624,7 @@ public int Native_GetAttribString(Handle plugin, int numParams) {
 	}
 	
 	// iterate over static attributes if it's not in runtime nor item server
-	if (!pRawValue) {
+	if (!pRawValue && HasEntProp(entity, Prop_Send, "m_iItemDefinitionIndex")) {
 		int itemdef = GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex");
 		int attrdefSOC;
 		any attrvalSOC;

--- a/scripting/tf2attributes.sp
+++ b/scripting/tf2attributes.sp
@@ -82,6 +82,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 	CreateNative("TF2Attrib_GetDefIndex", Native_GetID);
 	CreateNative("TF2Attrib_SetValue", Native_SetVal);
 	CreateNative("TF2Attrib_GetValue", Native_GetVal);
+	CreateNative("TF2Attrib_GetStringValue", Native_GetStringVal);
 	CreateNative("TF2Attrib_SetRefundableCurrency", Native_SetCurrency);
 	CreateNative("TF2Attrib_GetRefundableCurrency", Native_GetCurrency);
 	CreateNative("TF2Attrib_ClearCache", Native_ClearCache);
@@ -741,6 +742,18 @@ public int Native_SetVal(Handle plugin, int numParams) {
 public int Native_GetVal(Handle plugin, int numParams) {
 	Address pAttrib = GetNativeCell(1);
 	return LoadFromAddressOffset(pAttrib, 0x08, NumberType_Int32);
+}
+
+/* TF2Attrib_UnsafeGetStringValue(any pRawValue, char[] buffer, int maxlen); */
+public int Native_GetStringVal(Handle plugin, int numParams) {
+	Address pRawValue = GetNativeCell(1);
+	
+	int maxlen = GetNativeCell(3), length;
+	char[] buffer = new char[maxlen];
+	
+	ReadStringAttributeValue(pRawValue, buffer, maxlen);
+	SetNativeString(2, buffer, maxlen, .bytes = length);
+	return length;
 }
 
 /* native void TF2Attrib_SetRefundableCurrency(Address pAttrib, int nCurrency); */

--- a/scripting/tf2attributes.sp
+++ b/scripting/tf2attributes.sp
@@ -266,6 +266,7 @@ public void OnPluginStart() {
 	
 	// linux signature. this uses a hidden pointer passed in before `this` on the stack
 	// so we'll do our best with static since SM doesn't support that calling convention
+	// no subclasses override this virtual function so we'll just call it directly
 	StartPrepSDKCall(SDKCall_Static);
 	PrepSDKCall_SetFromConf(hGameConf, SDKConf_Signature, "CAttributeManager::ApplyAttributeStringWrapper");
 	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain); // return string_t

--- a/scripting/tf2attributes.sp
+++ b/scripting/tf2attributes.sp
@@ -614,7 +614,6 @@ public int Native_GetAttribString(Handle plugin, int numParams) {
 	
 	// iterate over static attributes if it's not in runtime nor item server
 	if (!pRawValue) {
-		PrintToServer("iterating static attribs");
 		int itemdef = GetEntProp(entity, Prop_Send, "m_iItemDefinitionIndex");
 		int attrdefSOC;
 		any attrvalSOC;


### PR DESCRIPTION
メリークリスマス

This PR introduces string attributes through the following changes:
- New native `TF2Attrib_SetFromStringValue`, which takes an attribute name and value string and performs any appropriate internal conversions (uses the same logic that the game uses for schema key / value parsing into values) and applies it as a runtime attribute.
  - The design for that native is intended for errors to be handled or ignored on the caller, instead of forcing them to perform pre-flight checks.  They should just be able to pass in a key / value pair and find out if it was successful or not after the fact.
- ~~New native `TF2Attrib_GetStringValue`, which takes a string attribute name and returns the first valid string value it finds for that attribute on an entity (prioritizing attributes applied on runtime, GC, then static).~~
  - ~~See comment further down in this PR; this native has a successor.~~
  - This native was removed.
- New native `TF2Attrib_UnsafeGetStringValue` to read arbitrary attribute string values instead of following the priority rules above.
- An internal heap-tracking system that manages heap-allocated runtime attributes.  The game doesn't manage such things itself (it only does this for GC and static attributes).  This needs a bit of work, but it should be fine as-is for getting this out the door (future work would include ~~be deduplicating strings and~~ cleaner unload logic).

The potential use cases for this include:
- Reading custom name / descriptions off weapons.
- Overwriting server-sided string attributes (this can be used to set `override projectile model`).
- Replacing [nosoop/SM-TFCustAttr][] by using an attribute injection method such as [Hidden Dev Attributes][].

This bumps up the minimum required SourceMod compiler version to 1.10.  I could backport the one enum struct that is used, but I think we should be fine not targeting anything older than the current stable release.

This supercedes and closes FlaminSarge/tf2attributes#41.

Mainly self-PRing this to CC @FlaminSarge for review, gotta make sure the API design looks fine

[nosoop/SM-TFCustAttr]: https://github.com/nosoop/SM-TFCustAttr
[Hidden Dev Attributes]: https://forums.alliedmods.net/showthread.php?t=326853